### PR TITLE
Implement Week Plan Management in Chef Dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/platform-browser": "^18.1.0",
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
+        "date-fns": "^3.6.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.3"
@@ -7366,6 +7367,16 @@
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/date-format": {
       "version": "4.0.14",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-browser": "^18.1.0",
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
+    "date-fns": "^3.6.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"

--- a/src/app/components/chef-dashboard/chef-dashboard.component.html
+++ b/src/app/components/chef-dashboard/chef-dashboard.component.html
@@ -1,2 +1,64 @@
-<h2>Chef Dashboard</h2>
-<p>Hier kannst du Menüs erstellen, bearbeiten und verwalten.</p>
+<h2>Menüplan Stiftung Bernaville</h2>
+<form [formGroup]="weekPlanForm" (ngSubmit)="saveWeekPlan()">
+  <mat-form-field appearance="fill">
+    <mat-label>Jahr</mat-label>
+    <input matInput formControlName="year" type="number" required />
+    <mat-error *ngIf="weekPlanForm.get('year')?.hasError('required')">
+      Jahr ist erforderlich
+    </mat-error>
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Kalenderwoche</mat-label>
+    <input matInput formControlName="weekNumber" type="number" required />
+    <mat-error *ngIf="weekPlanForm.get('weekNumber')?.hasError('required')">
+      Kalenderwoche ist erforderlich
+    </mat-error>
+  </mat-form-field>
+  <button mat-raised-button (click)="loadWeekPlan()">Wochenplan laden</button>
+  
+  <div formArrayName="days" class="day-cards">
+    <div *ngFor="let day of days.controls; let i=index" [formGroupName]="i">
+      <mat-card appearance="outlined">
+        <mat-card-header>
+          <mat-card-title>{{ day.get('date')?.value }}</mat-card-title>
+        </mat-card-header>
+        <mat-divider></mat-divider>
+        <mat-card-content>
+          <mat-card-header>
+            <mat-card-subtitle>Mittagessen</mat-card-subtitle>
+          </mat-card-header>
+          <mat-form-field appearance="fill">
+            <mat-label>BV-Menü</mat-label>
+            <input matInput formControlName="bvMenu" required />
+            <mat-error *ngIf="day.get('bvMenu')?.hasError('required')">
+              BV-Menü ist erforderlich
+            </mat-error>
+          </mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>Fleischlos</mat-label>
+            <input matInput formControlName="meatlessMenu" required />
+            <mat-error *ngIf="day.get('meatlessMenu')?.hasError('required')">
+              Fleischlos ist erforderlich
+            </mat-error>
+          </mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>Dessert</mat-label>
+            <input matInput formControlName="dessert" />
+          </mat-form-field>
+          <mat-divider></mat-divider>
+          <mat-card-header>
+            <mat-card-subtitle>Abendessen</mat-card-subtitle>
+          </mat-card-header>
+          <mat-form-field appearance="fill">
+            <mat-label>Abendessen</mat-label>
+            <input matInput formControlName="dinner" required />
+            <mat-error *ngIf="day.get('dinner')?.hasError('required')">
+              Abendessen ist erforderlich
+            </mat-error>
+          </mat-form-field>
+        </mat-card-content>
+      </mat-card>
+    </div>
+  </div>
+  <button mat-raised-button color="primary" type="submit" [disabled]="weekPlanForm.invalid">Wochenplan speichern</button>
+</form>

--- a/src/app/components/chef-dashboard/chef-dashboard.component.scss
+++ b/src/app/components/chef-dashboard/chef-dashboard.component.scss
@@ -1,8 +1,14 @@
-h2 {
-  text-align: center;
-  margin-bottom: 20px;
+.day-cards {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
 }
 
-p {
-  text-align: center;
+mat-card {
+  width: 100%;
+  margin: 10px 0;
+}
+
+mat-form-field {
+  width: 100%;
 }

--- a/src/app/components/chef-dashboard/chef-dashboard.component.ts
+++ b/src/app/components/chef-dashboard/chef-dashboard.component.ts
@@ -1,11 +1,155 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, FormArray, Validators, ReactiveFormsModule } from '@angular/forms';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { Firestore } from '@angular/fire/firestore';
 import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSelectModule } from '@angular/material/select';
+import { MatListModule } from '@angular/material/list';
+import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
+import { WeekPlan } from '../../models/week-plan.model';
+import { WeekPlanService } from '../../services/week-plan.service';
+import { startOfWeek, addDays, format, getISOWeek } from 'date-fns';
+import { de } from 'date-fns/locale';
 
 @Component({
   selector: 'app-chef-dashboard',
   standalone: true,
-  imports: [CommonModule],
   templateUrl: './chef-dashboard.component.html',
   styleUrls: ['./chef-dashboard.component.scss'],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatSnackBarModule,
+    MatFormFieldModule,
+    MatCardModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSelectModule,
+    MatListModule,
+    MatIconModule
+  ]
 })
-export class ChefDashboardComponent {}
+export class ChefDashboardComponent implements OnInit {
+  weekPlanForm: FormGroup;
+  weekPlan: WeekPlan | null = null;
+
+  constructor(
+    private fb: FormBuilder,
+    private snackBar: MatSnackBar,
+    private weekPlanService: WeekPlanService
+  ) {
+    const currentDate = new Date();
+    this.weekPlanForm = this.fb.group({
+      year: [currentDate.getFullYear(), Validators.required],
+      weekNumber: [getISOWeek(currentDate), Validators.required],
+      days: this.fb.array([])
+    });
+  }
+
+  ngOnInit(): void {
+    this.addDaysControls();
+    this.weekPlanForm.get('weekNumber')?.valueChanges.subscribe(() => {
+      this.updateDates();
+    });
+    this.weekPlanForm.get('year')?.valueChanges.subscribe(() => {
+      this.updateDates();
+    });
+    this.updateDates(); // Initiales Update der Daten
+  }
+
+  get days(): FormArray {
+    return this.weekPlanForm.get('days') as FormArray;
+  }
+
+  addDaysControls(): void {
+    const daysInWeek = 7;
+    for (let i = 0; i < daysInWeek; i++) {
+      this.days.push(this.fb.group({
+        date: ['', Validators.required],
+        bvMenu: ['', Validators.required],
+        meatlessMenu: ['', Validators.required],
+        dinner: ['', Validators.required],
+        dessert: ['']
+      }));
+    }
+    this.updateDates();
+  }
+
+  updateDates(): void {
+    const year = this.weekPlanForm.get('year')?.value;
+    const weekNumber = this.weekPlanForm.get('weekNumber')?.value;
+    if (year && weekNumber) {
+      const startDate = startOfWeek(new Date(year, 0, (weekNumber - 1) * 7 + 1), { weekStartsOn: 1, locale: de });
+      for (let i = 0; i < 7; i++) {
+        const date = addDays(startDate, i);
+        const formattedDate = format(date, 'dd/MM/yyyy');
+        const dayName = format(date, 'EEEE', { locale: de });
+        const dayControl = this.days.at(i);
+        dayControl.get('date')?.setValue(`${dayName} ${formattedDate}`, { emitEvent: false });
+      }
+    }
+  }
+
+  saveWeekPlan(): void {
+    if (this.weekPlanForm.valid) {
+      const weekPlan: WeekPlan = this.weekPlanForm.value;
+      this.weekPlanService.saveWeekPlan(weekPlan)
+        .then(() => {
+          this.snackBar.open('Week plan saved successfully', 'Close', { duration: 3000 });
+          this.resetForm();
+        })
+        .catch(error => {
+          this.snackBar.open('Error saving week plan: ' + error.message, 'Close', { duration: 3000 });
+        });
+    } else {
+      this.weekPlanForm.markAllAsTouched();
+    }
+  }
+
+  resetForm(): void {
+    const year = this.weekPlanForm.get('year')?.value;
+    const weekNumber = this.weekPlanForm.get('weekNumber')?.value;
+
+    this.weekPlanForm.reset({ year, weekNumber });
+
+    // Remove all controls from days FormArray and add them again
+    while (this.days.length) {
+      this.days.removeAt(0);
+    }
+    this.addDaysControls();
+    this.updateDates();
+
+    // Mark controls as pristine and untouched
+    this.weekPlanForm.markAsPristine();
+    this.weekPlanForm.markAsUntouched();
+    this.days.controls.forEach(control => {
+      control.markAsPristine();
+      control.markAsUntouched();
+    });
+  }
+
+  async loadWeekPlan(): Promise<void> {
+    const year = this.weekPlanForm.get('year')?.value;
+    const weekNumber = this.weekPlanForm.get('weekNumber')?.value;
+
+    this.resetForm();
+
+    const weekPlanExists = await this.weekPlanService.weekPlanExists(year, weekNumber);
+
+    if (weekPlanExists) {
+      const weekPlan = await this.weekPlanService.getWeekPlan(year, weekNumber);
+      if (weekPlan) {
+        this.weekPlan = weekPlan;
+        this.weekPlanForm.patchValue(weekPlan);
+        this.days.clear();
+        weekPlan.days.forEach(day => this.days.push(this.fb.group(day)));
+      }
+    } else {
+      this.snackBar.open('No week plan found for the selected week', 'Close', { duration: 3000 });
+    }
+  }
+}

--- a/src/app/models/menu.model.ts
+++ b/src/app/models/menu.model.ts
@@ -1,0 +1,6 @@
+export interface Menu {
+    id: string;
+    name: string;
+    description: string;
+    price: number;
+  }

--- a/src/app/models/week-plan.model.ts
+++ b/src/app/models/week-plan.model.ts
@@ -1,0 +1,13 @@
+export interface DayPlan {
+  date: string;
+  bvMenu: string;
+  meatlessMenu: string;
+  dinner: string;
+  dessert?: string;
+}
+
+export interface WeekPlan {
+  weekNumber: number;
+  year: number;
+  days: DayPlan[];
+}

--- a/src/app/services/week-plan.service.ts
+++ b/src/app/services/week-plan.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { Firestore, doc, setDoc, getDoc } from '@angular/fire/firestore';
+import { WeekPlan } from '../models/week-plan.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class WeekPlanService {
+  constructor(private firestore: Firestore) {}
+
+  saveWeekPlan(weekPlan: WeekPlan): Promise<void> {
+    const weekPlanDoc = doc(this.firestore, `weekPlans/${weekPlan.year}-${weekPlan.weekNumber}`);
+    return setDoc(weekPlanDoc, weekPlan);
+  }
+
+  async getWeekPlan(year: number, weekNumber: number): Promise<WeekPlan | undefined> {
+    const weekPlanDoc = doc(this.firestore, `weekPlans/${year}-${weekNumber}`);
+    const docSnap = await getDoc(weekPlanDoc);
+    return docSnap.exists() ? (docSnap.data() as WeekPlan) : undefined;
+  }
+
+  async weekPlanExists(year: number, weekNumber: number): Promise<boolean> {
+    const weekPlanDoc = doc(this.firestore, `weekPlans/${year}-${weekNumber}`);
+    const docSnap = await getDoc(weekPlanDoc);
+    return docSnap.exists();
+  }
+}


### PR DESCRIPTION
- Added form to manage week plans in the chef dashboard.
- Integrated date-fns to calculate dates based on year and week number.
- Implemented loading and saving week plans to Firebase Firestore.
- Added support for optional dessert field in the week plan.
- Ensured form resets correctly after saving, retaining the current year and week number.